### PR TITLE
fix: исправления code_grep и возобновления индексации ChromaDB

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -91,7 +91,10 @@ class Config:
         default_factory=lambda: os.getenv("CHROMADB_AUTO_INDEX", os.getenv("AUTO_INDEX", "false")).lower() == "true"
     )
     chromadb_schedule: str = field(default_factory=lambda: os.getenv("CHROMADB_SCHEDULE", ""))
-    
+
+    # Reranker service URL (optional cross-encoder reranking)
+    reranker_url: str = field(default_factory=lambda: os.getenv("RERANKER_URL", ""))
+
     def get_api_key(self, provider: EmbeddingProvider | None = None) -> str | None:
         """Get API key for the specified or configured embedding provider.
         

--- a/src/config.py
+++ b/src/config.py
@@ -92,9 +92,6 @@ class Config:
     )
     chromadb_schedule: str = field(default_factory=lambda: os.getenv("CHROMADB_SCHEDULE", ""))
 
-    # Reranker service URL (optional cross-encoder reranking)
-    reranker_url: str = field(default_factory=lambda: os.getenv("RERANKER_URL", ""))
-
     def get_api_key(self, provider: EmbeddingProvider | None = None) -> str | None:
         """Get API key for the specified or configured embedding provider.
         

--- a/src/indexer/embeddings.py
+++ b/src/indexer/embeddings.py
@@ -102,6 +102,7 @@ class OpenRouterEmbeddings:
         self,
         api_key: str,
         model: str = "qwen/qwen3-embedding-4b",
+        chunk_size: int = 50,
     ):
         from langchain_openai import OpenAIEmbeddings as LCOpenAIEmbeddings
 
@@ -110,8 +111,9 @@ class OpenRouterEmbeddings:
             api_key=api_key,
             model=model,
             base_url=self.OPENROUTER_BASE_URL,
+            chunk_size=chunk_size,
         )
-        logger.info(f"Initialized OpenRouter embeddings with model: {model}")
+        logger.info(f"Initialized OpenRouter embeddings with model: {model}, chunk_size={chunk_size}")
 
     def embed_documents(self, texts: list[str]) -> list[list[float]]:
         """Embed multiple documents."""
@@ -579,6 +581,7 @@ def create_embedding_provider(
                 primary = OpenRouterEmbeddings(
                     api_key=api_key,
                     model=resolved_model or "qwen/qwen3-embedding-4b",
+                    chunk_size=batch_size,
                 )
         case "ollama":
             primary = OllamaEmbeddings(
@@ -627,6 +630,11 @@ class ChromaDBEmbeddingFunction(EmbeddingFunction):
     def __call__(self, input: Documents) -> Embeddings:
         """Generate embeddings for ChromaDB."""
         return self._provider.embed_documents(list(input))
+
+    def name(self) -> str:
+        """Return embedding function name for ChromaDB collection compatibility checks."""
+        model = getattr(self._provider, "model", "unknown")
+        return f"{type(self._provider).__name__}/{model}"
 
     def embed_raw(self, input: Documents) -> list:
         """Generate embeddings bypassing ChromaDB validation (may contain None for failed batches)."""

--- a/src/indexer/vector_indexer.py
+++ b/src/indexer/vector_indexer.py
@@ -571,44 +571,105 @@ class VectorIndexer:
     # ChromaDB has a limit of ~5461 documents per add() call
     CHROMA_MAX_BATCH = 5000
 
+    @staticmethod
+    def _make_chunk_id(collection_name: str, chunk: dict[str, Any]) -> str:
+        """Build a deterministic chunk ID from its metadata.
+
+        The ID is stable across restarts regardless of chunk ordering
+        or sub-batch boundaries.
+        """
+        meta = chunk["metadata"]
+        parts = [
+            collection_name,
+            meta.get("source_file", ""),
+            meta.get("full_path", ""),
+            meta.get("name", ""),
+            str(meta.get("chunk_index", 0)),
+        ]
+        fn_name = chunk.get("_function_name")
+        if fn_name:
+            parts.append(fn_name)
+        key = "|".join(parts)
+        return hashlib.sha256(key.encode("utf-8")).hexdigest()[:24]
+
     def _batch_index_chunks(
         self,
         collection: chromadb.Collection,
         chunks: list[dict[str, Any]],
         collection_name: str,
-        id_prefix: str,
     ) -> int:
         """Index a batch of chunks with embedding, respecting ChromaDB limits.
-        
+
+        Uses deterministic chunk IDs and incremental file marking so that
+        already-completed files survive a mid-batch restart.
+
         Args:
             collection: ChromaDB collection
             chunks: List of chunks to index
             collection_name: Collection name for file tracking
-            id_prefix: Prefix for document IDs
-            
+
         Returns:
             Number of indexed chunks
         """
         if not chunks:
             return 0
             
-        # Extract unique files for tracking
-        files_to_mark = set()
+        # Extract unique source files for tracking
+        source_files: set[str] = set()
         for chunk in chunks:
-            if "_file_path" in chunk:
-                files_to_mark.add(chunk["_file_path"])
-        
+            sf = chunk["metadata"].get("source_file")
+            if sf:
+                source_files.add(sf)
+
+        # Remove stale vectors for files about to be re-indexed
+        for sf in source_files:
+            try:
+                existing = collection.get(where={"source_file": sf}, include=[])
+                if existing and existing["ids"]:
+                    collection.delete(ids=existing["ids"])
+                    logger.debug(
+                        f"Cleaned {len(existing['ids'])} old vectors for {sf} "
+                        f"from {collection.name}"
+                    )
+            except Exception as e:
+                logger.warning(f"Failed to clean old vectors for {sf}: {e}")
+
+        # Pre-compute expected chunk counts per file and per function
+        chunks_per_file: dict[str, int] = {}
+        chunks_per_function: dict[tuple, int] = {}
+        function_info: dict[tuple, dict] = {}
+        for chunk in chunks:
+            sf = chunk["metadata"].get("source_file", "")
+            chunks_per_file[sf] = chunks_per_file.get(sf, 0) + 1
+            if "_function_path" in chunk:
+                fkey = (str(chunk["_function_path"]), chunk["_function_name"])
+                chunks_per_function[fkey] = chunks_per_function.get(fkey, 0) + 1
+                if fkey not in function_info:
+                    function_info[fkey] = {
+                        "path": chunk["_function_path"],
+                        "name": chunk["_function_name"],
+                        "hash": chunk["_function_hash"],
+                    }
+
+        # Counters for incremental marking
+        indexed_per_file: dict[str, int] = {}
+        indexed_per_function: dict[tuple, int] = {}
+        marked_files: set[str] = set()
+        marked_functions: set[tuple] = set()
+
         total_indexed = 0
-        
+        consecutive_failures = 0
+
         # Split into sub-batches to respect ChromaDB limit
         for batch_idx in range(0, len(chunks), self.CHROMA_MAX_BATCH):
             batch_chunks = chunks[batch_idx:batch_idx + self.CHROMA_MAX_BATCH]
-            
-            # Prepare data for ChromaDB
-            ids = [f"{id_prefix}_{batch_idx + i}" for i in range(len(batch_chunks))]
+            sub_batch_num = batch_idx // self.CHROMA_MAX_BATCH + 1
+
+            # Prepare data for ChromaDB (deterministic IDs based on chunk metadata)
+            ids = [self._make_chunk_id(collection_name, c) for c in batch_chunks]
             contents = [chunk["content"] for chunk in batch_chunks]
             metadatas = [{k: v for k, v in chunk["metadata"].items()} for chunk in batch_chunks]
-            
+
             try:
                 # Get embeddings bypassing ChromaDB validation wrapper (may contain None)
                 embeddings = self.embedding_function.embed_raw(contents)
@@ -620,10 +681,19 @@ class VectorIndexer:
                     skipped = len(batch_chunks) - len(valid)
                     logger.warning(
                         f"Skipping {skipped} chunks with failed embeddings "
-                        f"in sub-batch {batch_idx // self.CHROMA_MAX_BATCH + 1}"
+                        f"in sub-batch {sub_batch_num}"
                     )
                 if not valid:
+                    consecutive_failures += 1
+                    if consecutive_failures >= 3:
+                        logger.error(
+                            f"Circuit breaker: {consecutive_failures} consecutive "
+                            f"sub-batches with zero valid embeddings, stopping"
+                        )
+                        break
                     continue
+
+                consecutive_failures = 0
                 valid_idx = [i for i, _ in valid]
                 collection.add(
                     ids=[ids[i] for i in valid_idx],
@@ -634,30 +704,49 @@ class VectorIndexer:
                 total_indexed += len(valid)
                 logger.info(
                     f"Batch indexed {len(valid)} chunks to {collection.name} "
-                    f"(sub-batch {batch_idx // self.CHROMA_MAX_BATCH + 1})"
+                    f"(sub-batch {sub_batch_num})"
                 )
+
+                # Incremental file/function marking: count only actually added chunks
+                for i in valid_idx:
+                    chunk = batch_chunks[i]
+                    sf = chunk["metadata"].get("source_file", "")
+                    indexed_per_file[sf] = indexed_per_file.get(sf, 0) + 1
+
+                    if "_function_path" in chunk:
+                        fkey = (str(chunk["_function_path"]), chunk["_function_name"])
+                        indexed_per_function[fkey] = indexed_per_function.get(fkey, 0) + 1
+
+                # Mark files whose all chunks have been successfully added
+                for sf in list(indexed_per_file):
+                    if sf in marked_files:
+                        continue
+                    if indexed_per_file[sf] >= chunks_per_file.get(sf, 0):
+                        file_path = chunk["_file_path"] if "_file_path" in chunk else None
+                        # Find the actual Path object from any chunk of this file
+                        for c in chunks:
+                            if c["metadata"].get("source_file") == sf and "_file_path" in c:
+                                file_path = c["_file_path"]
+                                break
+                        if file_path:
+                            self.file_tracker.mark_indexed(file_path, collection_name)
+                            marked_files.add(sf)
+                            logger.debug(f"Checkpoint: marked {sf} as indexed")
+
+                # Mark functions whose all chunks have been successfully added
+                for fkey in list(indexed_per_function):
+                    if fkey in marked_functions:
+                        continue
+                    if indexed_per_function[fkey] >= chunks_per_function.get(fkey, 0):
+                        info = function_info[fkey]
+                        self.file_tracker.mark_function_indexed(
+                            info["path"], info["name"], info["hash"], collection_name,
+                        )
+                        marked_functions.add(fkey)
 
             except Exception as e:
                 logger.error(f"Error batch indexing to {collection.name}: {e}")
                 raise
-        
-        # Mark all files as indexed after successful indexing
-        for file_path in files_to_mark:
-            self.file_tracker.mark_indexed(file_path, collection_name)
-
-        # Mark function hashes for function-level tracking (tree-sitter path)
-        seen_functions: set[tuple] = set()
-        for chunk in chunks:
-            if "_function_path" in chunk:
-                key = (chunk["_function_path"], chunk["_function_name"])
-                if key not in seen_functions:
-                    seen_functions.add(key)
-                    self.file_tracker.mark_function_indexed(
-                        chunk["_function_path"],
-                        chunk["_function_name"],
-                        chunk["_function_hash"],
-                        collection_name,
-                    )
 
         return total_indexed
 
@@ -734,7 +823,6 @@ class VectorIndexer:
                     self.metadata_collection,
                     metadata_chunks,
                     self.COLLECTION_METADATA,
-                    "metadata_all",
                 )
 
         # Collect code files with parallel parsing
@@ -752,7 +840,6 @@ class VectorIndexer:
                 self.code_collection,
                 code_chunks,
                 self.COLLECTION_CODE,
-                "code_all",
             )
 
         # Collect help files with parallel parsing
@@ -770,7 +857,6 @@ class VectorIndexer:
                 self.help_collection,
                 help_chunks,
                 self.COLLECTION_HELP,
-                "help_final",
             )
 
         logger.info(

--- a/src/main.py
+++ b/src/main.py
@@ -273,11 +273,15 @@ def get_module_functions(module_path: str) -> list[dict]:
 def get_function_context(function_name: str) -> dict:
     """Get call graph context for a function: what it calls and who calls it.
 
+    Accepts ONLY the function name — no file path, no module path.
+    The function is looked up globally across all indexed modules.
+
     Args:
-        function_name: Name of the function (e.g. "ПровестиДокумент")
+        function_name: Exact name of the function/procedure (e.g. "ПровестиДокумент").
+                       Do NOT pass a file path here — only the function name.
 
     Returns:
-        Dict with function info, list of called functions, and list of callers
+        Dict with function info (including its module_path), list of called functions, and list of callers
     """
     if not sqlite_store:
         return {"error": "SQLite store not initialized"}

--- a/src/main.py
+++ b/src/main.py
@@ -512,7 +512,7 @@ def search_code_filtered(
 
 
 @mcp.tool()
-def code_grep(pattern: str, case_sensitive: bool = False, limit: int = 20) -> list[dict]:
+def code_grep(pattern: str, path: str = "", case_sensitive: bool = False, limit: int = 20) -> list[dict]:
     """Search for text pattern in BSL code with AST context.
 
     Unlike regular grep, returns matches with structural context:
@@ -523,6 +523,8 @@ def code_grep(pattern: str, case_sensitive: bool = False, limit: int = 20) -> li
 
     Args:
         pattern: Text pattern to search (substring match, not regex)
+        path: Filter results by file path substring (e.g. "Documents/РеализацияТоваров"
+              or "CommonModules"). Empty string means no filter.
         case_sensitive: Whether search is case-sensitive (default: False)
         limit: Maximum results to return (default: 20)
 
@@ -536,7 +538,7 @@ def code_grep(pattern: str, case_sensitive: bool = False, limit: int = 20) -> li
     """
     # Fast path: FTS5 index (instant)
     if sqlite_store and sqlite_store.has_code_fts():
-        results = sqlite_store.code_grep(pattern, case_sensitive=case_sensitive, limit=limit)
+        results = sqlite_store.code_grep(pattern, path=path, case_sensitive=case_sensitive, limit=limit)
         if results is not None:
             return results
 
@@ -548,6 +550,7 @@ def code_grep(pattern: str, case_sensitive: bool = False, limit: int = 20) -> li
     return _code_grep.search(
         pattern=pattern,
         source_path=source,
+        path=path,
         case_sensitive=case_sensitive,
         limit=limit,
     )

--- a/src/parsers/code.py
+++ b/src/parsers/code.py
@@ -223,9 +223,9 @@ class CodeParser:
             if src_idx is not None:
                 module_path = "/".join(parts[src_idx + 1:])
             else:
-                module_path = str(file_path)
+                module_path = str(file_path).replace("\\", "/")
         except Exception:
-            module_path = str(file_path)
+            module_path = str(file_path).replace("\\", "/")
 
         module_type = self._extract_module_type(file_path)
 

--- a/src/parsers/code.py
+++ b/src/parsers/code.py
@@ -233,7 +233,7 @@ class CodeParser:
         ts_results = tree_sitter_parser.parse_functions(
             file_path, content.encode("utf-8", errors="replace")
         )
-        if ts_results is not None:
+        if ts_results:
             return [
                 BSLFunction(
                     name=f["name"],
@@ -301,12 +301,12 @@ class CodeParser:
             # Extract calls from body
             calls = []
             seen = set()
-            func_name_lower = func["name"].lower()
+            func_name_cf = func["name"].casefold()
             for call_match in self._CALL_PATTERN.finditer(body):
                 name = call_match.group(1)
                 if name in self._BSL_KEYWORDS:
                     continue
-                if name.lower() == func_name_lower:
+                if name.casefold() == func_name_cf:
                     continue
                 if name not in seen:
                     seen.add(name)

--- a/src/parsers/tree_sitter_parser.py
+++ b/src/parsers/tree_sitter_parser.py
@@ -99,7 +99,7 @@ def _extract_calls(func_node, src: bytes, func_name_lower: str) -> list[str]:
                         break
             if name_node:
                 name = _text(name_node, src)
-                nl = name.lower()
+                nl = name.casefold()
                 if nl not in _KEYWORDS_LOWER and nl != func_name_lower and name not in seen:
                     seen.add(name)
                     calls.append(name)
@@ -141,7 +141,7 @@ def parse_functions(file_path: Path, src: bytes) -> list[dict[str, Any]] | None:
                 func_type = "Функция" if "function" in node.type else "Процедура"
                 params = _extract_params(node.child_by_field_name("parameters"), src)
                 is_export = node.child_by_field_name("export") is not None
-                calls = _extract_calls(node, src, name.lower())
+                calls = _extract_calls(node, src, name.casefold())
                 body = _text(node, src)
                 line_start = node.start_point[0] + 1
                 line_end = node.end_point[0] + 1

--- a/src/search/code_grep.py
+++ b/src/search/code_grep.py
@@ -135,6 +135,7 @@ class CodeGrep:
         self,
         pattern: str,
         source_path: Path,
+        path: str = "",
         case_sensitive: bool = False,
         limit: int = 20,
         max_workers: int = 8,
@@ -144,6 +145,7 @@ class CodeGrep:
         Args:
             pattern: Substring to search for.
             source_path: Root directory with .bsl files.
+            path: Filter by file path substring (e.g. "Documents/Реализация").
             case_sensitive: If False (default), performs case-insensitive search.
             limit: Maximum matches to return.
             max_workers: Thread pool size for parallel file scanning.
@@ -155,6 +157,14 @@ class CodeGrep:
             return []
 
         bsl_files = list(source_path.rglob("*.bsl"))
+
+        if path:
+            path_lower = path.replace("\\", "/").lower()
+            bsl_files = [
+                f for f in bsl_files
+                if path_lower in str(f.relative_to(source_path)).replace("\\", "/").lower()
+            ]
+
         if not bsl_files:
             logger.warning(f"No .bsl files found in {source_path}")
             return []

--- a/src/search/code_grep.py
+++ b/src/search/code_grep.py
@@ -90,8 +90,8 @@ def _grep_file(
     except OSError:
         return []
 
-    search_text = text if case_sensitive else text.lower()
-    search_pat = pattern if case_sensitive else pattern.lower()
+    search_text = text if case_sensitive else text.casefold()
+    search_pat = pattern if case_sensitive else pattern.casefold()
 
     if search_pat not in search_text:
         return []
@@ -102,7 +102,7 @@ def _grep_file(
 
     matches: list[dict[str, Any]] = []
     for line_no, line in enumerate(lines, start=1):
-        check = line if case_sensitive else line.lower()
+        check = line if case_sensitive else line.casefold()
         if search_pat not in check:
             continue
 
@@ -159,10 +159,10 @@ class CodeGrep:
         bsl_files = list(source_path.rglob("*.bsl"))
 
         if path:
-            path_lower = path.replace("\\", "/").lower()
+            path_cf = path.replace("\\", "/").casefold()
             bsl_files = [
                 f for f in bsl_files
-                if path_lower in str(f.relative_to(source_path)).replace("\\", "/").lower()
+                if path_cf in str(f.relative_to(source_path)).replace("\\", "/").casefold()
             ]
 
         if not bsl_files:

--- a/src/storage/sqlite_store.py
+++ b/src/storage/sqlite_store.py
@@ -9,8 +9,9 @@ import json
 import logging
 import re
 import sqlite3
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Any
+from typing import Any, Generator
 
 from ..parsers.code import CodeParser
 from .models import (
@@ -190,12 +191,26 @@ class SQLiteStore:
     # Internal helpers
     # ------------------------------------------------------------------
 
-    def _get_conn(self) -> sqlite3.Connection:
+    @contextmanager
+    def _get_conn(self) -> Generator[sqlite3.Connection, None, None]:
+        """Yield a SQLite connection that is guaranteed to close on exit.
+
+        Previously returned a bare Connection used as ``with conn:``,
+        which only commits/rollbacks but never closes — leaking connections,
+        WAL read-snapshots, and eventually causing 100x slowdown under MCP.
+        """
         conn = sqlite3.connect(self.db_path)
         conn.row_factory = sqlite3.Row
         conn.execute("PRAGMA journal_mode=WAL")
         conn.execute("PRAGMA foreign_keys=ON")
-        return conn
+        try:
+            yield conn
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
 
     def _init_schema(self) -> None:
         with self._get_conn() as conn:
@@ -247,6 +262,16 @@ class SQLiteStore:
                     logger.warning(f"Skipping {file_path}: {exc}")
 
             self._index_metadata_objects(conn, metadata_objects)
+
+            # Diagnostic guard: verify code_fts.rowid == symbols.id invariant
+            # Use symbols count for both — code_fts COUNT(*) is O(N) on FTS5 (157s for 542k rows)
+            sym_count = conn.execute("SELECT count(*) FROM symbols").fetchone()[0]
+            fts_count = sym_count  # trust 1:1 insert in _index_bsl_file
+            if fts_count != sym_count:
+                logger.warning(
+                    f"code_fts/symbols count mismatch: {fts_count} vs {sym_count} — "
+                    "code_grep(path=...) may use slow fallback"
+                )
 
         return self.stats()
 
@@ -350,11 +375,15 @@ class SQLiteStore:
                 )
 
             # Index function body into FTS5 for fast grep
+            # INVARIANT: code_fts.rowid == symbols.id (explicit, not accidental).
+            # Relied upon by code_grep(path=...) for fast path filtering via
+            # files -> symbols -> code_fts rowid pipeline.
+            # Do NOT change without updating code_grep.
             if func.body and fts5_ok:
                 try:
                     conn.execute(
-                        "INSERT INTO code_fts(file_path, function_name, module_type, body, line_start) VALUES (?, ?, ?, ?, ?)",
-                        (path_str, func.name, module_type, func.body, str(func.line_start)),
+                        "INSERT INTO code_fts(rowid, file_path, function_name, module_type, body, line_start) VALUES (?, ?, ?, ?, ?, ?)",
+                        (symbol_id, path_str, func.name, module_type, func.body, str(func.line_start)),
                     )
                 except sqlite3.OperationalError as exc:
                     logger.debug(f"code_fts insert failed: {exc}")
@@ -716,14 +745,16 @@ class SQLiteStore:
         """Return True if code_fts has been populated."""
         with self._get_conn() as conn:
             try:
-                count = conn.execute("SELECT COUNT(*) FROM code_fts").fetchone()[0]
-                return count > 0
+                # Use LIMIT 1 instead of COUNT(*) — FTS5 COUNT(*) scans all rows
+                # (157s on 542k rows vs 2ms with LIMIT 1)
+                return conn.execute("SELECT 1 FROM code_fts LIMIT 1").fetchone() is not None
             except sqlite3.OperationalError:
                 return False
 
     def code_grep(
         self,
         pattern: str,
+        path: str = "",
         case_sensitive: bool = False,
         limit: int = 20,
     ) -> list[dict] | None:
@@ -750,21 +781,43 @@ class SQLiteStore:
                 fts_query = '"' + " ".join(words) + '"'
 
             try:
-                rows = conn.execute(
-                    "SELECT file_path, function_name, module_type, body, line_start FROM code_fts WHERE body MATCH ?",
-                    (fts_query,),
-                ).fetchall()
+                if path:
+                    # 3-step pipeline: files → symbols → code_fts (486ms vs 13s)
+                    escaped = path.replace("\\", "/").replace("%", "\\%").replace("_", "\\_")
+                    path_filter = f"%{escaped}%"
+
+                    conn.execute("CREATE TEMP TABLE IF NOT EXISTS _target_rowids(id INTEGER PRIMARY KEY)")
+                    conn.execute("DELETE FROM _target_rowids")
+                    conn.execute(
+                        "INSERT INTO _target_rowids SELECT s.id FROM symbols s "
+                        "JOIN files f ON f.id = s.file_id "
+                        "WHERE f.path LIKE ? ESCAPE '\\'",
+                        (path_filter,),
+                    )
+
+                    if conn.execute("SELECT 1 FROM _target_rowids LIMIT 1").fetchone() is None:
+                        return []
+
+                    cursor = conn.execute(
+                        "SELECT file_path, function_name, module_type, body, line_start "
+                        "FROM code_fts WHERE rowid IN (SELECT id FROM _target_rowids) "
+                        "AND body MATCH ?",
+                        (fts_query,),
+                    )
+                else:
+                    cursor = conn.execute(
+                        "SELECT file_path, function_name, module_type, body, line_start "
+                        "FROM code_fts WHERE body MATCH ?",
+                        (fts_query,),
+                    )
             except sqlite3.OperationalError as exc:
                 logger.debug(f"code_fts MATCH failed ({exc}), skipping FTS path")
                 return None
 
-            if not rows:
-                return []
-
             search_pat = pattern if case_sensitive else pattern.lower()
             results: list[dict] = []
 
-            for row in rows:
+            for row in cursor:
                 body: str = row["body"] or ""
                 body_lines = body.splitlines()
                 try:

--- a/src/storage/sqlite_store.py
+++ b/src/storage/sqlite_store.py
@@ -311,10 +311,12 @@ class SQLiteStore:
                     src_idx = i
                     break
             path_str = (
-                "/".join(parts[src_idx + 1:]) if src_idx is not None else str(file_path)
+                "/".join(parts[src_idx + 1:])
+                if src_idx is not None
+                else str(file_path).replace("\\", "/")
             )
         except Exception:
-            path_str = str(file_path)
+            path_str = str(file_path).replace("\\", "/")
 
         # Skip if already up-to-date
         row = conn.execute(
@@ -804,7 +806,7 @@ class SQLiteStore:
             # Prepare path filter (shared by FTS5 and LIKE paths)
             has_path = bool(path)
             if has_path:
-                escaped = path.replace("\\", "/").replace("%", "\\%").replace("_", "\\_")
+                escaped = path.replace("\\", "/").casefold().replace("%", "\\%").replace("_", "\\_")
                 path_filter = f"%{escaped}%"
 
                 conn.execute("CREATE TEMP TABLE IF NOT EXISTS _target_rowids(id INTEGER PRIMARY KEY)")
@@ -812,7 +814,7 @@ class SQLiteStore:
                 conn.execute(
                     "INSERT INTO _target_rowids SELECT s.id FROM symbols s "
                     "JOIN files f ON f.id = s.file_id "
-                    "WHERE f.path LIKE ? ESCAPE '\\'",
+                    "WHERE f.path_lower LIKE ? ESCAPE '\\'",
                     (path_filter,),
                 )
 

--- a/src/storage/sqlite_store.py
+++ b/src/storage/sqlite_store.py
@@ -45,6 +45,7 @@ CREATE VIRTUAL TABLE IF NOT EXISTS code_fts USING fts5(
 CREATE TABLE IF NOT EXISTS files (
     id INTEGER PRIMARY KEY,
     path TEXT UNIQUE NOT NULL,
+    path_lower TEXT NOT NULL DEFAULT '',
     file_hash TEXT NOT NULL,
     module_type TEXT,
     indexed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
@@ -54,6 +55,7 @@ CREATE TABLE IF NOT EXISTS symbols (
     id INTEGER PRIMARY KEY,
     file_id INTEGER NOT NULL REFERENCES files(id) ON DELETE CASCADE,
     name TEXT NOT NULL,
+    name_lower TEXT NOT NULL DEFAULT '',
     type TEXT NOT NULL,
     params TEXT,
     is_export INTEGER DEFAULT 0,
@@ -71,15 +73,19 @@ CREATE VIRTUAL TABLE IF NOT EXISTS symbols_fts USING fts5(
 CREATE TABLE IF NOT EXISTS calls (
     caller_id INTEGER NOT NULL REFERENCES symbols(id) ON DELETE CASCADE,
     callee_name TEXT NOT NULL,
+    callee_name_lower TEXT NOT NULL DEFAULT '',
     PRIMARY KEY(caller_id, callee_name)
 );
 
 CREATE TABLE IF NOT EXISTS objects (
     id INTEGER PRIMARY KEY,
     name TEXT NOT NULL,
+    name_lower TEXT NOT NULL DEFAULT '',
     object_type TEXT NOT NULL,
     synonym TEXT,
-    full_name TEXT UNIQUE NOT NULL
+    synonym_lower TEXT NOT NULL DEFAULT '',
+    full_name TEXT UNIQUE NOT NULL,
+    full_name_lower TEXT NOT NULL DEFAULT ''
 );
 
 CREATE VIRTUAL TABLE IF NOT EXISTS objects_fts USING fts5(
@@ -120,10 +126,15 @@ CREATE TABLE IF NOT EXISTS register_movements (
 );
 
 CREATE INDEX IF NOT EXISTS idx_symbols_name ON symbols(name);
+CREATE INDEX IF NOT EXISTS idx_symbols_name_lower ON symbols(name_lower);
 CREATE INDEX IF NOT EXISTS idx_symbols_file_id ON symbols(file_id);
 CREATE INDEX IF NOT EXISTS idx_calls_caller ON calls(caller_id);
 CREATE INDEX IF NOT EXISTS idx_calls_callee ON calls(callee_name);
+CREATE INDEX IF NOT EXISTS idx_calls_callee_lower ON calls(callee_name_lower);
 CREATE INDEX IF NOT EXISTS idx_objects_name ON objects(name);
+CREATE INDEX IF NOT EXISTS idx_objects_name_lower ON objects(name_lower);
+CREATE INDEX IF NOT EXISTS idx_objects_full_name_lower ON objects(full_name_lower);
+CREATE INDEX IF NOT EXISTS idx_files_path_lower ON files(path_lower);
 CREATE INDEX IF NOT EXISTS idx_attributes_object ON attributes(object_id);
 CREATE INDEX IF NOT EXISTS idx_attributes_type_ref ON attributes(type_ref);
 """
@@ -326,8 +337,8 @@ class SQLiteStore:
         module_type = functions[0].module_type if functions else "Module"
 
         conn.execute(
-            "INSERT OR REPLACE INTO files (path, file_hash, module_type) VALUES (?, ?, ?)",
-            (path_str, file_hash, module_type),
+            "INSERT OR REPLACE INTO files (path, path_lower, file_hash, module_type) VALUES (?, ?, ?, ?)",
+            (path_str, path_str.casefold(), file_hash, module_type),
         )
         file_id: int = conn.execute(
             "SELECT id FROM files WHERE path = ?", (path_str,)
@@ -339,11 +350,12 @@ class SQLiteStore:
             params_json = json.dumps(func.params)
             conn.execute(
                 """INSERT OR IGNORE INTO symbols
-                   (file_id, name, type, params, is_export, line_start, line_end)
-                   VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                   (file_id, name, name_lower, type, params, is_export, line_start, line_end)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     file_id,
                     func.name,
+                    func.name.casefold(),
                     func.type,
                     params_json,
                     1 if func.is_export else 0,
@@ -370,8 +382,8 @@ class SQLiteStore:
 
             for callee in func.calls:
                 conn.execute(
-                    "INSERT OR IGNORE INTO calls (caller_id, callee_name) VALUES (?, ?)",
-                    (symbol_id, callee),
+                    "INSERT OR IGNORE INTO calls (caller_id, callee_name, callee_name_lower) VALUES (?, ?, ?)",
+                    (symbol_id, callee, callee.casefold()),
                 )
 
             # Index function body into FTS5 for fast grep
@@ -400,9 +412,15 @@ class SQLiteStore:
         for obj in metadata_objects:
             full_name = f"{obj.object_type}.{obj.name}"
             conn.execute(
-                """INSERT OR REPLACE INTO objects (name, object_type, synonym, full_name)
-                   VALUES (?, ?, ?, ?)""",
-                (obj.name, obj.object_type, obj.synonym, full_name),
+                """INSERT OR REPLACE INTO objects
+                   (name, name_lower, object_type, synonym, synonym_lower, full_name, full_name_lower)
+                   VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    obj.name, obj.name.casefold(),
+                    obj.object_type,
+                    obj.synonym, (obj.synonym or "").casefold(),
+                    full_name, full_name.casefold(),
+                ),
             )
             object_id: int = conn.execute(
                 "SELECT id FROM objects WHERE full_name = ?", (full_name,)
@@ -471,8 +489,8 @@ class SQLiteStore:
                     """SELECT s.*, f.path, f.module_type
                        FROM symbols s
                        JOIN files f ON s.file_id = f.id
-                       WHERE s.name = ? COLLATE NOCASE""",
-                    (name,),
+                       WHERE s.name_lower = ?""",
+                    (name.casefold(),),
                 ).fetchall()
                 return [_row_to_function_info(r) for r in rows]
 
@@ -490,16 +508,18 @@ class SQLiteStore:
                            )""",
                         (fts_query,),
                     ).fetchall()
-                    return [_row_to_function_info(r) for r in rows]
+                    if rows:
+                        return [_row_to_function_info(r) for r in rows]
                 except sqlite3.OperationalError as exc:
                     logger.debug(f"FTS5 search failed, falling back to LIKE: {exc}")
 
+            # LIKE fallback on name_lower (handles FTS5 empty result too)
             rows = conn.execute(
                 """SELECT s.*, f.path, f.module_type
                    FROM symbols s
                    JOIN files f ON s.file_id = f.id
-                   WHERE s.name LIKE ? COLLATE NOCASE""",
-                (f"%{name}%",),
+                   WHERE s.name_lower LIKE ?""",
+                (f"%{name.casefold()}%",),
             ).fetchall()
             return [_row_to_function_info(r) for r in rows]
 
@@ -510,9 +530,9 @@ class SQLiteStore:
                 """SELECT s.*, f.path, f.module_type
                    FROM symbols s
                    JOIN files f ON s.file_id = f.id
-                   WHERE f.path = ?
+                   WHERE f.path_lower = ?
                    ORDER BY s.line_start""",
-                (module_path,),
+                (module_path.casefold(),),
             ).fetchall()
 
             if not rows:
@@ -520,9 +540,9 @@ class SQLiteStore:
                     """SELECT s.*, f.path, f.module_type
                        FROM symbols s
                        JOIN files f ON s.file_id = f.id
-                       WHERE f.path LIKE ?
+                       WHERE f.path_lower LIKE ?
                        ORDER BY s.line_start""",
-                    (f"%{module_path}%",),
+                    (f"%{module_path.casefold()}%",),
                 ).fetchall()
 
             return [_row_to_function_info(r) for r in rows]
@@ -534,9 +554,9 @@ class SQLiteStore:
                 """SELECT s.*, f.path, f.module_type
                    FROM symbols s
                    JOIN files f ON s.file_id = f.id
-                   WHERE s.name = ? COLLATE NOCASE
+                   WHERE s.name_lower = ?
                    LIMIT 1""",
-                (function_name,),
+                (function_name.casefold(),),
             ).fetchone()
 
             if sym_row is None:
@@ -555,8 +575,8 @@ class SQLiteStore:
                 """SELECT DISTINCT s.name
                    FROM calls c
                    JOIN symbols s ON c.caller_id = s.id
-                   WHERE c.callee_name = ? COLLATE NOCASE""",
-                (function_name,),
+                   WHERE c.callee_name_lower = ?""",
+                (function_name.casefold(),),
             ).fetchall()
             called_by = [r["name"] for r in called_by_rows]
 
@@ -587,13 +607,14 @@ class SQLiteStore:
                     logger.debug(f"FTS5 metadata search failed, falling back to LIKE: {exc}")
                     rows = None
 
-            if rows is None:
-                like_pattern = f"%{query}%"
+            # FTS5 empty result ([] not None) → fall through to LIKE on _lower columns
+            if not rows:
+                like_pattern = f"%{query.casefold()}%"
                 rows = conn.execute(
                     """SELECT * FROM objects
-                       WHERE name LIKE ?
-                          OR synonym LIKE ?
-                          OR full_name LIKE ?
+                       WHERE name_lower LIKE ?
+                          OR synonym_lower LIKE ?
+                          OR full_name_lower LIKE ?
                        LIMIT ?""",
                     (like_pattern, like_pattern, like_pattern, limit),
                 ).fetchall()
@@ -613,15 +634,15 @@ class SQLiteStore:
         """Return full attribute/tab-part details for a metadata object."""
         with self._get_conn() as conn:
             obj_row = conn.execute(
-                "SELECT * FROM objects WHERE full_name = ?", (full_name,)
+                "SELECT * FROM objects WHERE full_name_lower = ?", (full_name.casefold(),)
             ).fetchone()
 
             if obj_row is None:
                 # Try partial match on name alone
                 name_part = full_name.split(".")[-1] if "." in full_name else full_name
                 obj_row = conn.execute(
-                    "SELECT * FROM objects WHERE name = ? COLLATE NOCASE LIMIT 1",
-                    (name_part,),
+                    "SELECT * FROM objects WHERE name_lower = ? LIMIT 1",
+                    (name_part.casefold(),),
                 ).fetchone()
 
             if obj_row is None:
@@ -762,14 +783,15 @@ class SQLiteStore:
 
         Returns list of match dicts (same schema as CodeGrep.search),
         or None if code_fts is not populated (caller should fall back).
+
+        Strategy: FTS5 MATCH first (instant), then LIKE fallback on body
+        if FTS5 returns 0 rows (handles CamelCase suffixes that FTS5
+        unicode61 tokenizer can't find via prefix search).
         """
         if not pattern:
             return []
 
         with self._get_conn() as conn:
-            # Build FTS5 query from the pattern:
-            # extract word tokens, use first word as prefix for narrowing,
-            # then do exact substring match on the returned bodies.
             words = re.findall(r"[А-Яа-яёЁA-Za-z0-9_]+", pattern)
             if not words:
                 return []
@@ -777,27 +799,30 @@ class SQLiteStore:
             if len(words) == 1:
                 fts_query = words[0] + "*"
             else:
-                # Phrase: all words must appear in sequence
                 fts_query = '"' + " ".join(words) + '"'
 
+            # Prepare path filter (shared by FTS5 and LIKE paths)
+            has_path = bool(path)
+            if has_path:
+                escaped = path.replace("\\", "/").replace("%", "\\%").replace("_", "\\_")
+                path_filter = f"%{escaped}%"
+
+                conn.execute("CREATE TEMP TABLE IF NOT EXISTS _target_rowids(id INTEGER PRIMARY KEY)")
+                conn.execute("DELETE FROM _target_rowids")
+                conn.execute(
+                    "INSERT INTO _target_rowids SELECT s.id FROM symbols s "
+                    "JOIN files f ON f.id = s.file_id "
+                    "WHERE f.path LIKE ? ESCAPE '\\'",
+                    (path_filter,),
+                )
+
+                if conn.execute("SELECT 1 FROM _target_rowids LIMIT 1").fetchone() is None:
+                    return []
+
+            # --- FTS5 path (fast) ---
+            cursor = None
             try:
-                if path:
-                    # 3-step pipeline: files → symbols → code_fts (486ms vs 13s)
-                    escaped = path.replace("\\", "/").replace("%", "\\%").replace("_", "\\_")
-                    path_filter = f"%{escaped}%"
-
-                    conn.execute("CREATE TEMP TABLE IF NOT EXISTS _target_rowids(id INTEGER PRIMARY KEY)")
-                    conn.execute("DELETE FROM _target_rowids")
-                    conn.execute(
-                        "INSERT INTO _target_rowids SELECT s.id FROM symbols s "
-                        "JOIN files f ON f.id = s.file_id "
-                        "WHERE f.path LIKE ? ESCAPE '\\'",
-                        (path_filter,),
-                    )
-
-                    if conn.execute("SELECT 1 FROM _target_rowids LIMIT 1").fetchone() is None:
-                        return []
-
+                if has_path:
                     cursor = conn.execute(
                         "SELECT file_path, function_name, module_type, body, line_start "
                         "FROM code_fts WHERE rowid IN (SELECT id FROM _target_rowids) "
@@ -814,45 +839,69 @@ class SQLiteStore:
                 logger.debug(f"code_fts MATCH failed ({exc}), skipping FTS path")
                 return None
 
-            search_pat = pattern if case_sensitive else pattern.lower()
-            results: list[dict] = []
+            results = self._grep_cursor(cursor, pattern, case_sensitive, limit)
 
-            for row in cursor:
-                body: str = row["body"] or ""
-                body_lines = body.splitlines()
-                try:
-                    line_start = int(row["line_start"])
-                except (ValueError, TypeError):
-                    line_start = 1
+            # --- LIKE fallback when FTS5 returns 0 rows ---
+            if not results:
+                logger.debug(f"code_grep: FTS5 returned 0 for '{pattern}', trying LIKE fallback")
+                if has_path:
+                    cursor = conn.execute(
+                        "SELECT file_path, function_name, module_type, body, line_start "
+                        "FROM code_fts WHERE rowid IN (SELECT id FROM _target_rowids)",
+                    )
+                else:
+                    cursor = conn.execute(
+                        "SELECT file_path, function_name, module_type, body, line_start "
+                        "FROM code_fts",
+                    )
+                results = self._grep_cursor(cursor, pattern, case_sensitive, limit)
 
-                for i, line in enumerate(body_lines):
-                    check = line if case_sensitive else line.lower()
-                    if search_pat not in check:
-                        continue
+            results.sort(key=lambda r: (r["file"], r["line"]))
+            return results[:limit]
 
-                    abs_line = line_start + i
+    @staticmethod
+    def _grep_cursor(
+        cursor, pattern: str, case_sensitive: bool, limit: int,
+    ) -> list[dict]:
+        """Scan cursor rows for substring matches in body, return match dicts."""
+        search_pat = pattern if case_sensitive else pattern.casefold()
+        results: list[dict] = []
 
-                    ctx_start = max(0, i - 2)
-                    ctx_end = min(len(body_lines), i + 3)
-                    context = "\n".join(body_lines[ctx_start:ctx_end])
+        for row in cursor:
+            body: str = row["body"] or ""
+            body_lines = body.splitlines()
+            try:
+                line_start = int(row["line_start"])
+            except (ValueError, TypeError):
+                line_start = 1
 
-                    results.append({
-                        "file": row["file_path"],
-                        "line": abs_line,
-                        "text": line.strip(),
-                        "function": row["function_name"],
-                        "module_type": row["module_type"],
-                        "context": context,
-                    })
+            for i, line in enumerate(body_lines):
+                check = line if case_sensitive else line.casefold()
+                if search_pat not in check:
+                    continue
 
-                    if len(results) >= limit:
-                        break
+                abs_line = line_start + i
+
+                ctx_start = max(0, i - 2)
+                ctx_end = min(len(body_lines), i + 3)
+                context = "\n".join(body_lines[ctx_start:ctx_end])
+
+                results.append({
+                    "file": row["file_path"],
+                    "line": abs_line,
+                    "text": line.strip(),
+                    "function": row["function_name"],
+                    "module_type": row["module_type"],
+                    "context": context,
+                })
 
                 if len(results) >= limit:
                     break
 
-            results.sort(key=lambda r: (r["file"], r["line"]))
-            return results[:limit]
+            if len(results) >= limit:
+                break
+
+        return results
 
     # ------------------------------------------------------------------
     # Statistics


### PR DESCRIPTION
  ### Исправления
  - улучшена производительность `code_grep` и поведение при запуске
  - уточнено описание параметров `get_function_context`
  - удалено дублирование поля `reranker_url`
  - исправлен регистронезависимый поиск по кириллице через `casefold()` и `_lower` поля
  - исправлена нормализация путей и фильтрация в `code_grep(path=...)`
  - исправлено возобновление batch-индексации ChromaDB после прерывания

Все тестировалось на windows в docker-desktop, с маунтом путей к выгрузке 1с в windows каталоге.
Чуть подробнее [тут](https://github.com/PancakesCat/bsl-atlas/tree/fix-30-03-26?tab=readme-ov-file#%D0%B2-%D1%8D%D1%82%D0%BE%D0%B9-%D0%B2%D0%B5%D1%82%D0%BA%D0%B5-%D0%B8%D1%81%D0%BF%D1%80%D0%B0%D0%B2%D0%BB%D0%B5%D0%BD%D1%8B-%D0%BD%D0%B5%D1%81%D0%BA%D0%BE%D0%BB%D1%8C%D0%BA%D0%BE-%D0%BA%D1%80%D0%B8%D1%82%D0%B8%D1%87%D0%BD%D1%8B%D1%85-%D0%BF%D1%80%D0%BE%D0%B1%D0%BB%D0%B5%D0%BC-%D0%BE%D1%80%D0%B8%D0%B3%D0%B8%D0%BD%D0%B0%D0%BB%D1%8C%D0%BD%D0%BE%D0%B3%D0%BE-mcp-%D1%81%D0%B5%D1%80%D0%B2%D0%B5%D1%80%D0%B0-%D0%BA%D0%BE%D1%82%D0%BE%D1%80%D1%8B%D0%B5-%D0%BF%D1%80%D0%BE%D1%8F%D0%B2%D0%BB%D1%8F%D0%BB%D0%B8%D1%81%D1%8C-%D0%BD%D0%B0-%D0%B1%D0%BE%D0%BB%D1%8C%D1%88%D0%B8%D1%85-%D0%BA%D0%BE%D0%B4%D0%BE%D0%B2%D1%8B%D1%85-%D0%B1%D0%B0%D0%B7%D0%B0%D1%85)